### PR TITLE
fix/40

### DIFF
--- a/src/main/java/com/swygbro/trip/backend/domain/user/dto/GoogleUserInfo.java
+++ b/src/main/java/com/swygbro/trip/backend/domain/user/dto/GoogleUserInfo.java
@@ -14,4 +14,5 @@ public class GoogleUserInfo {
     private String email;
     private boolean verified_email;
     private String picture;
+    private String hd;
 }


### PR DESCRIPTION
- 기업용 구글 계정으로 구글 소셜 로그인 버그 해결
- 기업용 계정에는 구글 계정 정보에 hd 필드가 추가되는데 dto에서 시리얼라이즈 하지 못해 오류 발생
- dto 클래스에 hd 필드 추가
