### PR TITLE
fix/40

### DIFF
--- a/src/main/java/com/swygbro/trip/backend/domain/user/dto/GoogleUserInfo.java
+++ b/src/main/java/com/swygbro/trip/backend/domain/user/dto/GoogleUserInfo.java
@@ -14,4 +14,5 @@ public class GoogleUserInfo {
     private String email;
     private boolean verified_email;
     private String picture;
+    private String hd;
 }


### PR DESCRIPTION
- 기업용 계정 정보를 조회하면 hq라는 필드가 추가되는데 dto에 해당 필드가 없어서 시리얼라이즈 오류 발생
- dto에 hd 필드 추가